### PR TITLE
[Feature] Warn weak passwords

### DIFF
--- a/WpfApp/App.xaml.cs
+++ b/WpfApp/App.xaml.cs
@@ -26,7 +26,8 @@ public partial class App : Application
         ServiceCollection services = new();
 
         services.AddSingleton<IPasswordGenerator, CryptoPasswordGenerator>();
-        services.AddSingleton<IConfigurationProvider, JsonConfigurationProvider>();
+		services.AddSingleton<IPasswordStrengthCalculator, EntropyCalculator>();
+		services.AddSingleton<IConfigurationProvider, JsonConfigurationProvider>();
         services.AddTransient<MainViewModel>();
 
         return services.BuildServiceProvider();

--- a/WpfApp/Business/IPasswordStrengthCalculator/EntropyCalculator.cs
+++ b/WpfApp/Business/IPasswordStrengthCalculator/EntropyCalculator.cs
@@ -1,0 +1,26 @@
+﻿namespace Maiswan.Passwhat.WpfApp;
+
+public class EntropyCalculator : IPasswordStrengthCalculator
+{
+	private static bool IsPasswordWeak(double entropy)
+	{
+		return entropy < 80;
+	}
+
+	public bool IsPasswordWeak(int length, int poolSize)
+	{
+		double entropy = length * Math.Log2(poolSize);
+		return IsPasswordWeak(entropy);
+	}
+
+	public bool IsPasswordWeak(int length, string pool)
+	{
+		return IsPasswordWeak(length, pool.Length);
+	}
+
+	public bool IsPasswordWeak(string password, string pool)
+	{
+		return IsPasswordWeak(password.Length, pool);
+	}
+}
+

--- a/WpfApp/Business/IPasswordStrengthCalculator/IPasswordStrengthCalculator.cs
+++ b/WpfApp/Business/IPasswordStrengthCalculator/IPasswordStrengthCalculator.cs
@@ -1,0 +1,11 @@
+﻿namespace Maiswan.Passwhat.WpfApp;
+
+public interface IPasswordStrengthCalculator
+{
+	public bool IsPasswordWeak(int length, int poolSize);
+
+	public bool IsPasswordWeak(int length, string pool);
+
+	public bool IsPasswordWeak(string password, string pool);
+}
+

--- a/WpfApp/View/MainWindow.xaml
+++ b/WpfApp/View/MainWindow.xaml
@@ -16,11 +16,12 @@
     <Grid Name="Root">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Grid Margin="24,12">
+        <Grid Margin="24,12,24,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="5*"/>
                 <ColumnDefinition Width="*" MinWidth="64" MaxWidth="128"/>
@@ -31,13 +32,24 @@
                  IsReadOnly="True" IsReadOnlyCaretVisible="True"
                  FontSize="16" FontFamily="Cascadia Code,Courier New"/>
 
-
             <Button Grid.Column="1" Content="_Copy" Padding="8,0" Margin="2,0" Command="{Binding CopyCommand}"/>
             <Button Grid.Column="2" Content="_New" Padding="8,0" Command="{Binding RefreshCommand}"/>
-
         </Grid>
 
-        <ScrollViewer Grid.Row="1" Margin="24,0,24,8" VerticalScrollBarVisibility="Auto">
+        <TextBlock Margin="24,4"  Grid.Row="1" >
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsPasswordConfigWeak}" Value="True">
+                            <Setter Property="Text" Value="Weak password"/>
+                            <Setter Property="Foreground" Value="DarkRed"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+
+        <ScrollViewer Grid.Row="2" Margin="24,0,24,8" VerticalScrollBarVisibility="Auto">
             <StackPanel>
                 <GroupBox Header="Options" Padding="8">
                     <StackPanel>
@@ -60,7 +72,7 @@
                     </StackPanel>
                 </GroupBox>
 
-                <GroupBox Header="Copied Passwords" Padding="8,16" Margin="0,12">
+                <GroupBox Header="Copied Passwords" Padding="8,16" Margin="0,8,0,0">
                     <Grid>
                         <TextBlock Text="No copied passwords yet.">
                             <TextBlock.Style>
@@ -95,7 +107,7 @@
             </StackPanel>
         </ScrollViewer>
 
-        <StatusBar Grid.Row="2" Padding="24,4" VerticalAlignment="Bottom">
+        <StatusBar Grid.Row="3" Padding="24,4" VerticalAlignment="Bottom">
             <StatusBarItem Content="{Binding Status}"/>
             <StatusBarItem HorizontalAlignment="Right">
                 <TextBlock Text="{Binding Version, StringFormat='Build {0}'}"/>

--- a/WpfApp/ViewModel/MainViewModel.cs
+++ b/WpfApp/ViewModel/MainViewModel.cs
@@ -51,6 +51,8 @@ public partial class MainViewModel : ObservableObject
 
 	partial void OnSelectedCopiedPasswordChanged(string? value) => Copy(value);
 
+	[ObservableProperty]
+	private bool isPasswordConfigWeak;
 
 	[RelayCommand]
 	private void Copy(string? password)
@@ -90,6 +92,7 @@ public partial class MainViewModel : ObservableObject
 		char[] uniquePool = pool.ToCharArray().Distinct().ToArray();
 
 		Password = new(generator.GeneratePassword(uniquePool, Length));
+		IsPasswordConfigWeak = strength.IsPasswordWeak(Length, uniquePool.Length);
 		Status = $"Generated password {TruncatePassword(Password)}";
 	}
 
@@ -99,9 +102,10 @@ public partial class MainViewModel : ObservableObject
 		return password[0..7] + "...";
 	}
 
-    public MainViewModel(IPasswordGenerator generator, IConfigurationProvider config)
+    public MainViewModel(IPasswordGenerator generator, IPasswordStrengthCalculator strength, IConfigurationProvider config)
     {
 		this.generator = generator;
+		this.strength = strength;
 
 		Length = config.Configuration.Length;
 		CustomSet = config.Configuration.CustomSet;
@@ -114,4 +118,5 @@ public partial class MainViewModel : ObservableObject
     }
 
 	private readonly IPasswordGenerator generator;
+	private readonly IPasswordStrengthCalculator strength;
 }

--- a/WpfApp/WpfApp.csproj
+++ b/WpfApp/WpfApp.csproj
@@ -12,7 +12,7 @@
     <Company></Company>
     <Product></Product>
     <Authors>maiswan</Authors>
-	<Version>1.3.0.0</Version>
+	<Version>1.4.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a warning label should the selected password configuration produces weak passwords. The default implementation tests the configuration's entropy and enables the warning if it is below 80.